### PR TITLE
[fix] 開催日が誤りを修正

### DIFF
--- a/_data/events.yml
+++ b/_data/events.yml
@@ -20,7 +20,7 @@
 
 - url:   https://dojocon2023.coderdojo.jp/
   img:   2023.webp
-  date:  2023/08/27 (土)
+  date:  2023/08/27 (日)
   venue: 奈良
   description: >-
     2012年に日本で最初の CoderDojo が始まって昨年で10年が経ち、現在では多くの企業や組織から支援を受けられるようになりました。これは CoderDojo が任意かつ自律的な活動であるにも関わらず信頼を得られている証だと考えられます。<br>
@@ -29,7 +29,7 @@
 
 - url:   https://dojocon2022.coderdojo.jp/
   img:   2022.webp
-  date:  2022/11/12 (土)
+  date:  2022/11/27 (日)
   venue: 富山
   description: >-
     2016・2017年は大阪、2018年は東京、2019年は名古屋で開催しました。2020年・2021年はコロナウイルスの流行の影響でオンラインでの開催となりました。そして7回目の今年は現地開催を復活して富山県で開催！<br>
@@ -38,7 +38,7 @@
 
 - url:   https://dojocon2021.coderdojo.jp/
   img:   2021.webp
-  date:  2021//12/18 (土)
+  date:  2021/12/18 (土)
   venue: オンライン
   description: >-
     2021年は CoderDojo が10周年を迎え、DojoCon Japan も昨年の開催で通算5回目を数えました。とてもめでたいので皆で集まってお祝いしましょう。<br>
@@ -72,7 +72,7 @@
 
 - url:   https://dojocon2017.coderdojo.jp/
   img:   2017.webp
-  date:  2017/11/07 (土)
+  date:  2017/11/04 (土)
   venue: 大阪
   description: >-
     今回は、「つながる Dojo to Dojo 」をテーマに、全国の CoderDojo 関係者が集まることで交流や意見交換を行ったり、一生付き合える仲間づくりをすることで、日本の CoderDojo コミュニティの絆を強めることを目的に開催します。DojoCon Japan に参加してもらうことで、「CoderDojo」という同じ活動をしているのに、他の Dojo のことを余り知らないという課題を解決し、相互理解を深めることでそこから新しい何かが生まれることを期待しています。また、これまで CoderDojo を知らなかった方にもこの機会に知っていただき、地元の Dojo に参加したり、新しく Dojo を立ち上げるきっかけになってほしいと願っています。


### PR DESCRIPTION
DojoConのホームページにおいて過去の開催日の日付が間違っているので修正しました。

ご確認よろしくお願いします。